### PR TITLE
Updating for v9: update dependencies and run linter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '*.md'
+  pull_request:
+    paths-ignore:
+      - '*.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18, 20]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - "6"
-  - "8"
-  - "10"
-  - "node"
-

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
   },
   "devDependencies": {
     "chai": "^4.3.4",
-    "eslint": "^8.2.0",
-    "eslint-plugin-prettier": "^4.0.0",
-    "husky": "^7.0.4",
-    "lint-staged": "^12.0.3",
-    "mocha": "^9.1.3",
+    "eslint": "^8.49.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "husky": "^8.0.3",
+    "lint-staged": "^14.0.1",
+    "mocha": "^10.2.0",
     "mocha-chai-jest-snapshot": "^1.1.3",
-    "prettier": "^2.4.1"
+    "prettier": "^3.0.3"
   },
   "lint-staged": {
     "src/**/*.js": [

--- a/src/test/lexer-test.js
+++ b/src/test/lexer-test.js
@@ -1,11 +1,11 @@
-const { expect } = require('chai');
-const { getTokens } = require('../lib/lexer');
+const { expect } = require('chai')
+const { getTokens } = require('../lib/lexer')
 
 describe('Lexer', () => {
   it('tokenizes a basic JSON object', () => {
     const result = getTokens({
       foo: 'bar'
-    });
+    })
 
     expect(result).to.deep.equal([
       { type: 'BRACE', value: '{' },
@@ -13,11 +13,11 @@ describe('Lexer', () => {
       { type: 'COLON', value: ':' },
       { type: 'STRING_LITERAL', value: '"bar"' },
       { type: 'BRACE', value: '}' }
-    ]);
-  });
+    ])
+  })
 
   it('tokenizes a basic JSON string', () => {
-    const result = getTokens('{"foo":"bar"}');
+    const result = getTokens('{"foo":"bar"}')
 
     expect(result).to.deep.equal([
       { type: 'BRACE', value: '{' },
@@ -25,11 +25,11 @@ describe('Lexer', () => {
       { type: 'COLON', value: ':' },
       { type: 'STRING_LITERAL', value: '"bar"' },
       { type: 'BRACE', value: '}' }
-    ]);
-  });
+    ])
+  })
 
   it('tokenizes an array', () => {
-    const result = getTokens(['foo', 'bar']);
+    const result = getTokens(['foo', 'bar'])
 
     expect(result).to.deep.equal([
       { type: 'BRACKET', value: '[' },
@@ -37,11 +37,11 @@ describe('Lexer', () => {
       { type: 'COMMA', value: ',' },
       { type: 'STRING_LITERAL', value: '"bar"' },
       { type: 'BRACKET', value: ']' }
-    ]);
-  });
+    ])
+  })
 
   it('includes whitespace', () => {
-    const result = getTokens('{\n  "foo": "bar"\n}');
+    const result = getTokens('{\n  "foo": "bar"\n}')
 
     expect(result).to.deep.equal([
       { type: 'BRACE', value: '{' },
@@ -52,75 +52,75 @@ describe('Lexer', () => {
       { type: 'STRING_LITERAL', value: '"bar"' },
       { type: 'WHITESPACE', value: '\n' },
       { type: 'BRACE', value: '}' }
-    ]);
-  });
+    ])
+  })
 
   it('tokenizes boolean values', () => {
-    let result = getTokens('true');
-    expect(result).to.deep.equal([{ type: 'BOOLEAN_LITERAL', value: 'true' }]);
+    let result = getTokens('true')
+    expect(result).to.deep.equal([{ type: 'BOOLEAN_LITERAL', value: 'true' }])
 
-    result = getTokens('false');
-    expect(result).to.deep.equal([{ type: 'BOOLEAN_LITERAL', value: 'false' }]);
-  });
+    result = getTokens('false')
+    expect(result).to.deep.equal([{ type: 'BOOLEAN_LITERAL', value: 'false' }])
+  })
 
   it('tokenizes integer values', () => {
-    let result = getTokens('123');
-    expect(result).to.deep.equal([{ type: 'NUMBER_LITERAL', value: '123' }]);
+    let result = getTokens('123')
+    expect(result).to.deep.equal([{ type: 'NUMBER_LITERAL', value: '123' }])
 
-    result = getTokens('-10');
-    expect(result).to.deep.equal([{ type: 'NUMBER_LITERAL', value: '-10' }]);
-  });
+    result = getTokens('-10')
+    expect(result).to.deep.equal([{ type: 'NUMBER_LITERAL', value: '-10' }])
+  })
 
   it('tokenizes a decimal number', () => {
-    const result = getTokens('1.234');
-    expect(result).to.deep.equal([{ type: 'NUMBER_LITERAL', value: '1.234' }]);
-  });
+    const result = getTokens('1.234')
+    expect(result).to.deep.equal([{ type: 'NUMBER_LITERAL', value: '1.234' }])
+  })
 
   it('tokenizes a scientific notation number', () => {
-    let result = getTokens('12e5');
-    expect(result).to.deep.equal([{ type: 'NUMBER_LITERAL', value: '12e5' }]);
+    let result = getTokens('12e5')
+    expect(result).to.deep.equal([{ type: 'NUMBER_LITERAL', value: '12e5' }])
 
-    result = getTokens('12e+5');
-    expect(result).to.deep.equal([{ type: 'NUMBER_LITERAL', value: '12e+5' }]);
+    result = getTokens('12e+5')
+    expect(result).to.deep.equal([{ type: 'NUMBER_LITERAL', value: '12e+5' }])
 
-    result = getTokens('12E-5');
-    expect(result).to.deep.equal([{ type: 'NUMBER_LITERAL', value: '12E-5' }]);
-  });
+    result = getTokens('12E-5')
+    expect(result).to.deep.equal([{ type: 'NUMBER_LITERAL', value: '12E-5' }])
+  })
 
   it('tokenizes null', () => {
-    const result = getTokens('null');
-    expect(result).to.deep.equal([{ type: 'NULL_LITERAL', value: 'null' }]);
-  });
+    const result = getTokens('null')
+    expect(result).to.deep.equal([{ type: 'NULL_LITERAL', value: 'null' }])
+  })
 
   it('tokenizes a string literal with brace characters', () => {
-    const result = getTokens('"{hello}"');
-    expect(result).to.deep.equal([{ type: 'STRING_LITERAL', value: '"{hello}"' }]);
-  });
+    const result = getTokens('"{hello}"')
+    expect(result).to.deep.equal([{ type: 'STRING_LITERAL', value: '"{hello}"' }])
+  })
 
   it('tokenizes a string literal with bracket characters', () => {
-    const result = getTokens('"[hello]"');
-    expect(result).to.deep.equal([{ type: 'STRING_LITERAL', value: '"[hello]"' }]);
-  });
+    const result = getTokens('"[hello]"')
+    expect(result).to.deep.equal([{ type: 'STRING_LITERAL', value: '"[hello]"' }])
+  })
 
   it('tokenizes a string literal with an escaped quote', () => {
-    const result = getTokens('"a\\"b"');
-    expect(result).to.deep.equal([{ type: 'STRING_LITERAL', value: '"a\\"b"' }]);
-  });
+    const result = getTokens('"a\\"b"')
+    expect(result).to.deep.equal([{ type: 'STRING_LITERAL', value: '"a\\"b"' }])
+  })
 
   it('tokenizes a key-value pair with whitespace between the :', () => {
-    const result = getTokens('"foo" : "bar"');
+    const result = getTokens('"foo" : "bar"')
     expect(result).to.deep.equal([
       { type: 'STRING_KEY', value: '"foo"' },
       { type: 'WHITESPACE', value: ' ' },
       { type: 'COLON', value: ':' },
       { type: 'WHITESPACE', value: ' ' },
       { type: 'STRING_LITERAL', value: '"bar"' }
-    ]);
-  });
+    ])
+  })
 
   it('given an undefined json when get token should have no results', () => {
-    const result = getTokens(undefined);
+    const result = getTokens(undefined)
 
-    expect(result).to.deep.equal([]);
-  });
-});
+    expect(result).to.deep.equal([])
+  })
+})


### PR DESCRIPTION
Hello!
Here I updated all dependencies that were outdated, and tests ran as expected.
As @jsumners mentioned, we could have a problem with deps switching to ESM-only, but to be honest I did not find a way of programmatically understanding if they are or not, so if you have any suggestions please share!